### PR TITLE
Add custom conenction form

### DIFF
--- a/airflow_provider_fivetran/__init__.py
+++ b/airflow_provider_fivetran/__init__.py
@@ -1,0 +1,8 @@
+def get_provider_info():
+  return {
+      "package-name": "airflow-provider-fivetran",
+      "name": "Fivetran Provider",
+      "description": "An Apache Airflow Provider for Fivetran.",
+      "hook-class-names": ["airflow_provider_fivetran.hooks.fivetran.FivetranHook"],
+      "versions": ["0.0.1"]
+  }

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,9 @@ python_requires = >=3.6
 install_requires =
     requests
     apache-airflow >= 1.10
+
+[options.entry_points]
+# the function get_provider_info is defined in myproviderpackage.somemodule
+apache_airflow_provider=
+  provider_info=airflow_provider_fivetran.__init__:get_provider_info
+


### PR DESCRIPTION
This PR creates a custom Fivetran connection that is discoverable by Airflow. A user can now pick Fivetran from a dropdown menu when adding a connection and get a form to fill out tailored to Fivetran.

screenshot:

![image](https://user-images.githubusercontent.com/63181127/111694586-72ad2d80-8808-11eb-8b53-1864f0dcc3c7.png)
