### PR TITLE
Adds Registry Link for Operator to UI

### DIFF
--- a/airflow_provider_fivetran/__init__.py
+++ b/airflow_provider_fivetran/__init__.py
@@ -4,5 +4,6 @@ def get_provider_info():
       "name": "Fivetran Provider",
       "description": "An Apache Airflow Provider for Fivetran.",
       "hook-class-names": ["airflow_provider_fivetran.hooks.fivetran.FivetranHook"],
+      "extra-links":["airflow_provider_fivetran.operators.fivetran.RegistryLink"],
       "versions": ["0.0.1"]
   }

--- a/airflow_provider_fivetran/hooks/fivetran.py
+++ b/airflow_provider_fivetran/hooks/fivetran.py
@@ -91,11 +91,11 @@ class FivetranHook(BaseHook):
         """
         method, connector_id = endpoint_info
 
-        if 'token' in self.fivetran_conn.extra_dejson:
+        if "extra__fivetran__token" in self.fivetran_conn.extra_dejson:
             self.log.info('Using token auth. ')
-            auth = _TokenAuth(self.fivetran_conn.extra_dejson['extra__fivetran__token'])
-            if 'host' in self.fivetran_conn.extra_dejson:
-                host = self._parse_host(self.fivetran_conn.extra_dejson['host'])
+            auth = _TokenAuth(self.fivetran_conn.extra_dejson["extra__fivetran__token"])
+            if "host" in self.fivetran_conn.extra_dejson:
+                host = self._parse_host(self.fivetran_conn.extra_dejson["host"])
             else:
                 host = self.fivetran_conn.host
         else:

--- a/airflow_provider_fivetran/hooks/fivetran.py
+++ b/airflow_provider_fivetran/hooks/fivetran.py
@@ -92,6 +92,7 @@ class FivetranHook(BaseHook):
         method, connector_id = endpoint_info
 
         if 'token' in self.fivetran_conn.extra_dejson:
+            self.log.info('Using token auth. ')
             auth = _TokenAuth(self.fivetran_conn.extra_dejson['extra__fivetran__token'])
             if 'host' in self.fivetran_conn.extra_dejson:
                 host = self._parse_host(self.fivetran_conn.extra_dejson['host'])

--- a/airflow_provider_fivetran/operators/fivetran.py
+++ b/airflow_provider_fivetran/operators/fivetran.py
@@ -11,8 +11,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from airflow_provider_fivetran.hooks.fivetran import FivetranHook
 
-REGISTRY_LINK = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
-
 class RegistryLink(BaseOperatorLink):
     """Link to Registry"""
 
@@ -23,18 +21,6 @@ class RegistryLink(BaseOperatorLink):
 
         registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
         return registry_link.format(provider='fivetran', operator='fivetranoperator')
-
-class RegistryLink(BaseOperatorLink):
-    """Link to Registry"""
-
-    name = 'Astronomer Registry'
-
-    def get_link(self, operator, dttm):
-        """Get link to registry page."""
-
-        registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
-        return registry_link.format(provider='fivetran', operator='fivetranoperator')
-
 
 class FivetranOperator(BaseOperator):
     """

--- a/airflow_provider_fivetran/operators/fivetran.py
+++ b/airflow_provider_fivetran/operators/fivetran.py
@@ -31,8 +31,9 @@ class RegistryLink(BaseOperatorLink):
 
     def get_link(self, operator, dttm):
         """Get link to registry page."""
-    
-        return REGISTRY_LINK.format(provider='fivetran', operator='fivetranoperator')
+
+        registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
+        return registry_link.format(provider='fivetran', operator='fivetranoperator')
 
 
 class FivetranOperator(BaseOperator):

--- a/airflow_provider_fivetran/operators/fivetran.py
+++ b/airflow_provider_fivetran/operators/fivetran.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from airflow_provider_fivetran.hooks.fivetran import FivetranHook
 
-log = logging.getLogger(__name__)
+REGISTRY_LINK = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
 
 class RegistryLink(BaseOperatorLink):
     """Link to Registry"""
@@ -23,6 +23,16 @@ class RegistryLink(BaseOperatorLink):
 
         registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
         return registry_link.format(provider='fivetran', operator='fivetranoperator')
+
+class RegistryLink(BaseOperatorLink):
+    """Link to Registry"""
+
+    name = 'Astronomer Registry'
+
+    def get_link(self, operator, dttm):
+        """Get link to registry page."""
+    
+        return REGISTRY_LINK.format(provider='fivetran', operator='fivetranoperator')
 
 
 class FivetranOperator(BaseOperator):

--- a/airflow_provider_fivetran/operators/fivetran.py
+++ b/airflow_provider_fivetran/operators/fivetran.py
@@ -11,9 +11,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from airflow_provider_fivetran.hooks.fivetran import FivetranHook
 
-REGISTRY_LINK = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
-
-
 log = logging.getLogger(__name__)
 
 class RegistryLink(BaseOperatorLink):
@@ -23,8 +20,9 @@ class RegistryLink(BaseOperatorLink):
 
     def get_link(self, operator, dttm):
         """Get link to registry page."""
-    
-        return REGISTRY_LINK.format(provider='fivetran', operator='fivetranoperator')
+
+        registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
+        return registry_link.format(provider='fivetran', operator='fivetranoperator')
 
 
 class FivetranOperator(BaseOperator):

--- a/airflow_provider_fivetran/operators/fivetran.py
+++ b/airflow_provider_fivetran/operators/fivetran.py
@@ -1,8 +1,30 @@
-from airflow.models import BaseOperator
+import logging
+import json
+import time
+
+import requests
+
+from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.utils.decorators import apply_defaults
-from typing import Optional
+from typing import Any, Dict, List, Optional, Union
+
 
 from airflow_provider_fivetran.hooks.fivetran import FivetranHook
+
+REGISTRY_LINK = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
+
+
+log = logging.getLogger(__name__)
+
+class RegistryLink(BaseOperatorLink):
+    """Link to Registry"""
+
+    name = 'Astronomer Registry'
+
+    def get_link(self, operator, dttm):
+        """Get link to registry page."""
+    
+        return REGISTRY_LINK.format(provider='fivetran', operator='fivetranoperator')
 
 
 class FivetranOperator(BaseOperator):
@@ -23,6 +45,8 @@ class FivetranOperator(BaseOperator):
         for sync status; 3 seconds is about the minimum before hitting rate limits.
     :type poll_frequency: Optional[int]
     """
+
+    operator_extra_links = (RegistryLink(),)
 
     @apply_defaults
     def __init__(

--- a/airflow_provider_fivetran/operators/fivetran.py
+++ b/airflow_provider_fivetran/operators/fivetran.py
@@ -8,7 +8,6 @@ from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.utils.decorators import apply_defaults
 from typing import Any, Dict, List, Optional, Union
 
-
 from airflow_provider_fivetran.hooks.fivetran import FivetranHook
 
 class RegistryLink(BaseOperatorLink):


### PR DESCRIPTION
This PR adds a link to the Astronomer Registry Fivetran Operator Page in the Airflow UI. This is done similar to the discoverable hook. An "extra-links" key is added to the function get_provider_info() which is read as an entrypoint in setup.cfg

![image](https://user-images.githubusercontent.com/63181127/111785352-e136cd80-8892-11eb-872f-9e59f4648ce1.png)
