### PR TITLE
Cleaning up Hook: Connection host optional, methods pass endpoints not connector_ids

### DIFF
--- a/airflow_provider_fivetran/__init__.py
+++ b/airflow_provider_fivetran/__init__.py
@@ -5,5 +5,5 @@ def get_provider_info():
       "description": "An Apache Airflow Provider for Fivetran.",
       "hook-class-names": ["airflow_provider_fivetran.hooks.fivetran.FivetranHook"],
       "extra-links":["airflow_provider_fivetran.operators.fivetran.RegistryLink"],
-      "versions": ["0.0.1"]
+      "versions": ["0.1.0"]
   }

--- a/airflow_provider_fivetran/hooks/fivetran.py
+++ b/airflow_provider_fivetran/hooks/fivetran.py
@@ -92,7 +92,6 @@ class FivetranHook(BaseHook):
         :rtype: dict
         """
         method, connector_id = endpoint_info
-<<<<<<< HEAD
 
         if "extra__fivetran__token" in self.fivetran_conn.extra_dejson:
             self.log.info("Using token auth. (This is unusual, standard is Basic Auth)")
@@ -105,10 +104,6 @@ class FivetranHook(BaseHook):
             auth = (self.fivetran_conn.login, self.fivetran_conn.password)
             host = self.fivetran_conn.host
 
-=======
-        auth = (self.fivetran_conn.login, self.fivetran_conn.password)
-        host = self.fivetran_conn.host
->>>>>>> main
         url = host + connector_id + force
 
         if method == "GET":

--- a/airflow_provider_fivetran/hooks/fivetran.py
+++ b/airflow_provider_fivetran/hooks/fivetran.py
@@ -32,6 +32,9 @@ class FivetranHook(BaseHook):
     default_conn_name = 'fivetran_default'
     conn_type = 'fivetran'
     hook_name = 'Fivetran'
+    api_protocol = 'https'
+    api_host = 'api.fivetran.com'
+    api_path_connectors = '/v1/connectors/'
 
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
@@ -91,7 +94,7 @@ class FivetranHook(BaseHook):
         method, connector_id = endpoint_info
 
         if "extra__fivetran__token" in self.fivetran_conn.extra_dejson:
-            self.log.info('Using token auth. ')
+            self.log.info("Using token auth. (This is unusual, standard is Basic Auth)")
             auth = _TokenAuth(self.fivetran_conn.extra_dejson["extra__fivetran__token"])
             if "host" in self.fivetran_conn.extra_dejson:
                 host = self._parse_host(self.fivetran_conn.extra_dejson["host"])

--- a/airflow_provider_fivetran/sensors/fivetran.py
+++ b/airflow_provider_fivetran/sensors/fivetran.py
@@ -1,15 +1,11 @@
-from typing import Any, Callable, Dict, Optional
-
-import pendulum
-import logging
-import json
+from typing import Any
 
 from airflow.exceptions import AirflowException
-from hooks.fivetran import FivetranHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 
-log = logging.getLogger(__name__)
+from airflow_provider_fivetran.hooks.fivetran import FivetranHook
+
 
 class FivetranSensor(BaseSensorOperator):
     """
@@ -24,10 +20,6 @@ class FivetranSensor(BaseSensorOperator):
     :param poke_interval: Time in seconds that the job should wait in
         between each tries
     :type poke_interval: int
-    :param hook: FivetranHook that will provide interaction with Fivetran API
-    :type hook: airflow_provider_fivetran.hook.FivetranHook
-    :param previous_completed_at: The number of seconds to wait between retries.
-    :type previous_completed_at: pendulum.datetime.DateTime
     """
     @apply_defaults
     def __init__(
@@ -35,12 +27,8 @@ class FivetranSensor(BaseSensorOperator):
         fivetran_conn_id: str = 'fivetran',
         poke_interval: int = 60,
         connector_id=None,
-        hook=None,
-        previous_completed_at=None,
         **kwargs: Any
     ) -> None:
-        
-
         super().__init__(**kwargs)
         self.fivetran_conn_id = fivetran_conn_id
         self.connector_id = connector_id
@@ -48,9 +36,5 @@ class FivetranSensor(BaseSensorOperator):
         self.hook = FivetranHook(self.fivetran_conn_id)
         self.previous_completed_at = self.hook.get_last_sync(self.connector_id)
 
-
     def poke(self, context):
        return self.hook.get_sync_status(self.connector_id, self.previous_completed_at)
-
-
- 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = airflow-provider-fivetran
-version = 0.0.2
+version = 0.1.0
 description = A Fivetran provider for Apache Airflow
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -10,7 +10,7 @@ classifiers =
     Programming Language :: Python :: 3
     Operating System :: OS Independent
 
-author = Fivetran Developer Relations
+author = Fivetran
 author_email = devrel@fivetran.com
 url = https://github.com/fivetran/airflow-provider-fivetran
 project_urls =


### PR DESCRIPTION
Previous to this revision, it was **required** to pass the following as the connection host:

`https://api.fivetran.com/v1/connectors/`

This has a few problems, the most obvious being that is not a hostname. Beyond that, it limits the flexibility of the hook long-term to make calls to non-connector endpoints; beyond that, there is no reason a user should have to configure that extremely default information. With this commit, the Connection host can be left blank or the user can specify a hostname (e.g. `api.fivetran.com`). 

Additionally, I cleaned up the methods to pass endpoint paths as the metaphor, rather than `connection_id`. This is more in-line with the level of abstraction being handled in this class. The user passes `connection_id` in, the methods are expected to know how to translate that to the correct endpoint to implement their function. 