### PR TITLE
doc(readme): light copyedit for clarity and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache Airflow Provider for Fivetran
 
-Provides an Airflow operator, sensor, and hook for [Fivetran](https://fivetran.com). This allows you to start Fivetran jobs from Airflow, and monitor a Fivetran sync job for completion before running downstream processes.
+This package provides an Airflow operator, sensor, and hook for [Fivetran](https://fivetran.com). `FivetranOperator` allows you to start Fivetran jobs from Airflow and `FivetranSensor` allows you to monitor a Fivetran sync job for completion before running downstream processes.
 
 Fivetran automates your data pipeline, and Airflow automates your data processing.
 
@@ -27,24 +27,24 @@ The sensor and operator assume the `Conn Id` is set to `fivetran`, however if yo
 
 ## Modules
 
-### [Fivetran Operator](./fivetran_provider/operators/fivetran.py)
+### [FivetranOperator](./fivetran_provider/operators/fivetran.py)
 
-The Fivetran Operator starts a Fivetran sync job. Note that when a Fivetran sync job is controlled via an Operator, it is no longer run on the schedule as managed by Fivetran. In other words, it is now scheduled only from Airflow.
+`FivetranOperator` starts a Fivetran sync job. Note that when a Fivetran sync job is controlled via an Operator, it is no longer run on the schedule as managed by Fivetran. In other words, it is now scheduled only from Airflow.
 
-`FivetranOperator` requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran interface](https://fivetran.com/dashboard/connectors).
+`FivetranOperator` requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran dashboard](https://fivetran.com/dashboard/connectors).
 
 Import into your DAG via:
 ```
 from fivetran_provider.operators.fivetran import FivetranOperator
 ```
 
-### [Fivetran Sensor](./fivetran_provider/sensors/fivetran.py)
+### [FivetranSensor](./fivetran_provider/sensors/fivetran.py)
 
-The Fivetran Sensor monitors a Fivetran sync job for completion. Monitoring allows you to trigger downstream processes only when one or more Fivetran sync jobs have completed, ensuring data consistency.
+`FivetranSensor` monitors a Fivetran sync job for completion. Monitoring allows you to trigger downstream processes only when one or more Fivetran sync jobs have completed, ensuring data consistency.
 
 Note, it is possible to monitor a sync that is scheduled and manaaged from Fivetran; in other words, you can use `FivetranSensor` without using `FivetranOperator`. If used in this way, your DAG will wait until the sync job starts on its Fivetran-controlled schedule and then completes.
 
-`FivetranSensor` requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran interface](https://fivetran.com/dashboard/connectors).
+`FivetranSensor` requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran dashboard](https://fivetran.com/dashboard/connectors).
 
 Import into your DAG via:
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fivetran automates your data pipeline, and Airflow automates your data processin
 
 ## Installation
 
-Pre-requisites: An environment running `apache-airflow`.
+Prerequisites: An environment running `apache-airflow`.
 
 ```
 pip install airflow-provider-fivetran
@@ -14,14 +14,14 @@ pip install airflow-provider-fivetran
 
 ## Configuration
 
-In the Airflow user interface, you will need to configure a Connection for Fivetran. Most of the Connection config fields will be left blank. Configure the following fields:
+In the Airflow user interface, configure a Connection for Fivetran. Most of the Connection config fields will be left blank. Configure the following fields:
 
 * `Conn Id`: `fivetran`
 * `Conn Type`: `HTTP`
 * `Login`: Fivetran API Key
 * `Password`: Fivetran API Secret
 
-Fivetran API Key and Secret can be found in the [Fivetran Account Settings](https://fivetran.com/account/settings), under the **API Config** section. Please see our documentation for more information on [Fivetran API Authentication](https://fivetran.com/docs/rest-api/getting-started#authentication).
+Find the Fivetran API Key and Secret in the [Fivetran Account Settings](https://fivetran.com/account/settings), under the **API Config** section. See our documentation for more information on [Fivetran API Authentication](https://fivetran.com/docs/rest-api/getting-started#authentication).
 
 The sensor and operator assume the `Conn Id` is set to `fivetran`, however if you are managing multipe Fivetran accounts, you can set this to anything you like. See the DAG in examples to see how to specify a custom `Conn Id`.
 
@@ -29,7 +29,7 @@ The sensor and operator assume the `Conn Id` is set to `fivetran`, however if yo
 
 ### [Fivetran Operator](./fivetran_provider/operators/fivetran.py)
 
-Starts a Fivetran sync job. Note that when a Fivetran sync job is controlled via an Operator, it is no longer run on the schedule as managed by Fivetran. In other words, it is now scheduled only from Airflow.
+The Fivetran Operator starts a Fivetran sync job. Note that when a Fivetran sync job is controlled via an Operator, it is no longer run on the schedule as managed by Fivetran. In other words, it is now scheduled only from Airflow.
 
 `FivetranOperator` requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran interface](https://fivetran.com/dashboard/connectors).
 
@@ -40,7 +40,7 @@ from fivetran_provider.operators.fivetran import FivetranOperator
 
 ### [Fivetran Sensor](./fivetran_provider/sensors/fivetran.py)
 
-Monitors a Fivetran sync job for completion. This allows you to trigger downstream processes only when one or more Fivetran sync jobs have completed, ensuring data consistency.
+The Fivetran Sensor monitors a Fivetran sync job for completion. Monitoring allows you to trigger downstream processes only when one or more Fivetran sync jobs have completed, ensuring data consistency.
 
 Note, it is possible to monitor a sync that is scheduled and manaaged from Fivetran; in other words, you can use `FivetranSensor` without using `FivetranOperator`. If used in this way, your DAG will wait until the sync job starts on its Fivetran-controlled schedule and then completes.
 
@@ -60,7 +60,7 @@ See the [**examples**](./fivetran_provider/example_dags) directory for an exampl
 Please submit [issues](https://github.com/fivetran/airflow-provider-fivetran/issues) and [pull requests](https://github.com/fivetran/airflow-provider-fivetran/pulls) in our official repo:
 [https://github.com/fivetran/airflow-provider-fivetran](https://github.com/fivetran/airflow-provider-fivetran)
 
-We are happy to hear from you, for any feedback please email the authors at [devrel@fivetran.com](mailto:devrel@fivetran.com).
+We are happy to hear from you. Please email any feedback to the authors at [devrel@fivetran.com](mailto:devrel@fivetran.com).
 
 
 ## Acknowledgements


### PR DESCRIPTION
This is a light copyedit of the readme to improve clarity by specifying antecedents, removing passive voice where appropriate, and making some other cosmetic style changes to bring it closer to Fivetran docs style.

I have some questions and comments about this document.

- Will your audience definitely know what "DAG" stands for? It's an acronym you use throughout the readme but never expand.
- You use "Fivetran interface" as the keyword to link to what I would call the "Fivetran dashboard." If you would like to be more consistent with Fivetran docs, change it to "Fivetran dashboard." But if you think your audience will understand "Fivetran interface" better, keep it.
- "Provides an Airflow operator, sensor, and hook for Fivetran" is not a complete sentence. I realize it carries on from the title but some readers might find it jarring. I tried re-writing it as "Apache Airflow Provider for Fivetran provides an Airflow operator, sensor, and hook for Fivetran," and while that's a complete sentence it's repetitive and terrible. Do you have a better idea? (If not, keep it. Fast and lose with grammar is better than wasting readers' time.)
- "This allows you to start Fivetran jobs from Airflow..." "This" is somewhat unclear here. What part of "this" allows the user to do that? The whole Airflow provider? Some interaction of the operator, sensor and hook? You can see other places in the doc where I've replaced "this" with something more specific where I was able to guess what it should be. See if you can do that here. 
- Throughout, you introduce code snippets without being very clear about where a user should put them. Do you think it will be super obvious to your audience? If there's any doubt, you might want to be specific. 

I edited out one of your "pleases" on the principle that instructions are like recipes. It doesn't make sense to say "Please crack three eggs." But I kept the "please" requesting feedback because there it's more personal. (Breaking my own rule about never having courtesies in tech docs, but it felt right.)
