### PR TITLE
Airflow native UI integration improvements

### DIFF
--- a/fivetran_provider/example_dags/example_fivetran.py
+++ b/fivetran_provider/example_dags/example_fivetran.py
@@ -18,14 +18,14 @@ dag = DAG(
 fivetran_sync_start = FivetranOperator(
     task_id='fivetran-task',
     fivetran_conn_id='fivetran_default',
-    connector_id="{{ var.value.get('connector_id', 'fallback_connector_id') }}",
+    connector_id="{{ var.value.get('connector_id') }}",
     dag=dag
 )
 
 fivetran_sync_wait = FivetranSensor(
     task_id='fivetran-sensor',
     fivetran_conn_id='fivetran_default',
-    connector_id="{{ var.value.get('connector_id', 'fallback_connector_id') }}",
+    connector_id="{{ var.value.get('connector_id') }}",
     poke_interval=5,
     dag=dag
 )

--- a/fivetran_provider/hooks/fivetran.py
+++ b/fivetran_provider/hooks/fivetran.py
@@ -39,26 +39,12 @@ class FivetranHook(BaseHook):
 
 
     @staticmethod
-    def get_connection_form_widgets() -> Dict[str, Any]:
-        """Returns connection widgets to add to connection form"""
-        from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget
-        from flask_babel import lazy_gettext
-        from wtforms import PasswordField
-
-        return {
-            "extra__fivetran__token": PasswordField(
-                lazy_gettext('Token'), widget=BS3PasswordFieldWidget()
-            ),
-        }
-
-    @staticmethod
     def get_ui_field_behaviour() -> Dict:
         """Returns custom field behaviour"""
         return {
-            "hidden_fields": ['schema', 'port', 'extra'],
+            "hidden_fields": ['host', 'schema', 'port', 'extra'],
             "relabeling": {},
             "placeholders": {
-                'host': 'Fivetran API Hostname',
                 'login': 'Fivetran API Key',
                 'password': 'Fivetran API Secret',
             },
@@ -94,9 +80,7 @@ class FivetranHook(BaseHook):
         """
         method, endpoint = endpoint_info
         auth = (self.fivetran_conn.login, self.fivetran_conn.password)
-        host = self.fivetran_conn.host
-        host = host if host is not None and host != "" else self.api_host
-        url = f"{self.api_protocol}://{host}/{endpoint}"
+        url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
 
         headers = {
             "User-Agent": self.api_user_agent
@@ -326,17 +310,3 @@ def _retryable_error(exception) -> bool:
         or exception.response is not None
         and exception.response.status_code >= 500
     )
-
-
-class _TokenAuth(AuthBase):
-    """
-    Helper class for requests Auth field. AuthBase requires you to implement the
-        __call__ magic function.
-    """
-
-    def __init__(self, token: str) -> None:
-        self.token = token
-
-    def __call__(self, r: PreparedRequest) -> PreparedRequest:
-        r.headers["Authorization"] = "Bearer " + self.token
-        return r


### PR DESCRIPTION
Narrows the Connection fields required down to `login` and `password`, representing API Key and API Secret, respectively. 

Removes the `fallback_connector_id` from the example_dag.py, we'd rather have these fail if a connector is not specified.