### PR TITLE
Updating example DAGs + operator and sensor signatures

### DIFF
--- a/fivetran_provider/example_dags/example_fivetran.py
+++ b/fivetran_provider/example_dags/example_fivetran.py
@@ -1,33 +1,35 @@
-import airflow
 from airflow import DAG
-from airflow.models import Variable
+
 from fivetran_provider.operators.fivetran import FivetranOperator
 from fivetran_provider.sensors.fivetran import FivetranSensor
+
+from datetime import datetime, timedelta
 
 
 default_args = {
     "owner": "Airflow",
-    "start_date": airflow.utils.dates.days_ago(1)
+    "start_date": datetime(2021, 4, 6),
 }
 
 dag = DAG(
     dag_id='example_fivetran',
-    default_args=default_args
+    default_args=default_args,
+    schedule_interval=timedelta(days=1),
+    catchup=False,
 )
 
-fivetran_sync_start = FivetranOperator(
-    task_id='fivetran-task',
-    fivetran_conn_id='fivetran_default',
-    connector_id="{{ var.value.get('connector_id') }}",
-    dag=dag
-)
+with dag:
+    fivetran_sync_start = FivetranOperator(
+        task_id='fivetran-task',
+        fivetran_conn_id='fivetran_default',
+        connector_id="{{ var.value.connector_id }}",
+    )
 
-fivetran_sync_wait = FivetranSensor(
-    task_id='fivetran-sensor',
-    fivetran_conn_id='fivetran_default',
-    connector_id="{{ var.value.get('connector_id') }}",
-    poke_interval=5,
-    dag=dag
-)
+    fivetran_sync_wait = FivetranSensor(
+        task_id='fivetran-sensor',
+        fivetran_conn_id='fivetran_default',
+        connector_id="{{ var.value.connector_id }}",
+        poke_interval=5,
+    )
 
-fivetran_sync_start >> fivetran_sync_wait
+    fivetran_sync_start >> fivetran_sync_wait

--- a/fivetran_provider/example_dags/example_fivetran_bigquery.py
+++ b/fivetran_provider/example_dags/example_fivetran_bigquery.py
@@ -47,13 +47,13 @@ with DAG('example_fivetran_bigquery',
     fivetran_sync_start = FivetranOperator(
         task_id='fivetran-task',
         fivetran_conn_id='fivetran_default',
-        connector_id='{{ var.value.get("connector_id") }}'
+        connector_id='{{ var.value.connector_id }}'
     )
 
     fivetran_sync_wait = FivetranSensor(
         task_id='fivetran-sensor',
         fivetran_conn_id='fivetran_default',
-        connector_id='{{ var.value.get("connector_id") }}',
+        connector_id='{{ var.value.connector_id }}',
         poke_interval=5
     )
 
@@ -64,7 +64,7 @@ with DAG('example_fivetran_bigquery',
     """
     validate_bigquery = BigQueryTableExistenceSensor(
         task_id='validate_bigquery',
-        project_id=Variable.get('gcp_project_id'),
+        project_id='{{ var.value.gcp_project_id }}',
         dataset_id=DATASET,
         table_id='forestfires',
     )

--- a/fivetran_provider/example_dags/example_fivetran_bigquery.py
+++ b/fivetran_provider/example_dags/example_fivetran_bigquery.py
@@ -1,5 +1,4 @@
 from airflow import DAG, AirflowException
-from airflow.models import Variable
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.providers.google.cloud.sensors.bigquery import BigQueryTableExistenceSensor
 from airflow.providers.google.cloud.operators.bigquery import BigQueryValueCheckOperator

--- a/fivetran_provider/example_dags/example_fivetran_dbt.py
+++ b/fivetran_provider/example_dags/example_fivetran_dbt.py
@@ -1,56 +1,53 @@
-import os
-import airflow
 from airflow import DAG
-from airflow.models import Variable
 from airflow.providers.ssh.operators.ssh import SSHOperator
-from airflow_provider_fivetran.operators.fivetran import FivetranOperator
-from airflow_provider_fivetran.sensors.fivetran import FivetranSensor
+
+from fivetran_provider.operators.fivetran import FivetranOperator
+from fivetran_provider.sensors.fivetran import FivetranSensor
+
+from datetime import datetime, timedelta
 
 
 default_args = {
     "owner": "Airflow",
-    "start_date": airflow.utils.dates.days_ago(1)
+    "start_date": datetime(2021, 4, 6),
 }
 
 dag = DAG(
-    dag_id='ad_reporting_dag',
-    default_args=default_args
+    dag_id="ad_reporting_dag",
+    default_args=default_args,
+    schedule_interval=timedelta(days=1),
+    catchup=False,
 )
 
-linkedin_sync = FivetranOperator(
-    task_id='linkedin-ads-sync',
-    connector_id=Variable.get("linkedin_connector_id"),
-    dag=dag
-)
+with dag:
+    linkedin_sync = FivetranOperator(
+        task_id="linkedin-ads-sync",
+        connector_id="{{ var.value.linkedin_connector_id }}",
+    )
 
+    linkedin_sensor = FivetranSensor(
+        task_id="linkedin-sensor",
+        connector_id="{{ var.value.linkedin_connector_id }}",
+        poke_interval=600,
+    )
 
-linkedin_sensor = FivetranSensor(
-    connector_id=Variable.get("linkedin_connector_id"),
-    poke_interval=600,
-    task_id='linkedin-sensor',
-    dag=dag
-)
+    twitter_sync = FivetranOperator(
+        task_id="twitter-ads-sync",
+        connector_id="{{ var.value.twitter_connector_id }}",
+    )
 
-twitter_sync = FivetranOperator(
-    task_id='twitter-ads-sync',
-    connector_id=Variable.get("twitter_connector_id"),
-    dag=dag
-)
+    twitter_sensor = FivetranSensor(
+        task_id="twitter-sensor",
+        connector_id="{{ var.value.twitter_connector_id }}",
+        poke_interval=600,
+    )
 
-twitter_sensor = FivetranSensor(
-    connector_id=Variable.get("twitter_connector_id"),
-    poke_interval=600,
-    task_id='twitter-sensor',
-    dag=dag
-)
+    dbt_run = SSHOperator(
+        task_id="dbt_ad_reporting",
+        command="cd dbt_ad_reporting ; ~/.local/bin/dbt run -m +ad_reporting",
+        ssh_conn_id="dbtvm",
+    )
 
-dbt_run = SSHOperator(
-    task_id='dbt_ad_reporting',
-    command='cd dbt_ad_reporting ; ~/.local/bin/dbt run -m +ad_reporting',
-    ssh_conn_id='dbtvm',
-    dag=dag
-  )
-
-linkedin_sync >> linkedin_sensor
-twitter_sync >> twitter_sensor
-[linkedin_sensor, twitter_sensor] >> dbt_run
+    linkedin_sync >> linkedin_sensor
+    twitter_sync >> twitter_sensor
+    [linkedin_sensor, twitter_sensor] >> dbt_run

--- a/fivetran_provider/operators/fivetran.py
+++ b/fivetran_provider/operators/fivetran.py
@@ -1,26 +1,22 @@
-import logging
-import json
-import time
-
-import requests
-
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.utils.decorators import apply_defaults
-from typing import Any, Dict, List, Optional, Union
 
 from fivetran_provider.hooks.fivetran import FivetranHook
+from typing import Optional
 
 
 class RegistryLink(BaseOperatorLink):
     """Link to Registry"""
 
-    name = 'Astronomer Registry'
+    name = "Astronomer Registry"
 
     def get_link(self, operator, dttm):
         """Get link to registry page."""
 
-        registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
-        return registry_link.format(provider='fivetran', operator='fivetranoperator')
+        registry_link = (
+            "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
+        )
+        return registry_link.format(provider="fivetran", operator="fivetranoperator")
 
 
 class FivetranOperator(BaseOperator):
@@ -54,12 +50,12 @@ class FivetranOperator(BaseOperator):
     @apply_defaults
     def __init__(
         self,
+        connector_id: str,
         run_name: Optional[str] = None,
         timeout_seconds: Optional[int] = None,
-        fivetran_conn_id: str = 'fivetran',
+        fivetran_conn_id: str = "fivetran",
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,
-        connector_id: str = None,
         poll_frequency: int = 15,
         **kwargs
     ):

--- a/fivetran_provider/sensors/fivetran.py
+++ b/fivetran_provider/sensors/fivetran.py
@@ -1,10 +1,8 @@
-from typing import Any
-
-from airflow.exceptions import AirflowException
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 
 from fivetran_provider.hooks.fivetran import FivetranHook
+from typing import Any
 
 
 class FivetranSensor(BaseSensorOperator):
@@ -44,11 +42,11 @@ class FivetranSensor(BaseSensorOperator):
     @apply_defaults
     def __init__(
         self,
-        fivetran_conn_id: str = 'fivetran',
+        connector_id: str,
+        fivetran_conn_id: str = "fivetran",
         poke_interval: int = 60,
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,
-        connector_id=None,
         **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)


### PR DESCRIPTION
Hey guys! I joined the Astronomer team with Pete, David, and Plinio about 2 months ago and we have been working on exposing DAGs on the Astronomer Registry as first-class citizens ([check Fivetran's DAGs out here](https://registry.astronomer.io/dags?providers=Fivetran)).  I'm sad I missed being able to collaborate on your provider package earlier but I made some updates to the example DAGs as well as some small changes to modules.  Let me know if you have any questions!

- Updating example DAGs for best practices:
  - Modified the `start_date` to have a static value.
  - Added `catchup=False` expression to the DAG definition.
  - Using the `DAG` object as a context manager.
  - Added an explicit `schedule_interval` (the default value from `airflow.models.DAG`).
  - Removed unused modules from import statements.
  - Updated explicit `Variable.get()` call to a Jinja expression.
  - Updated the `{{ var.value.get(...) }}` call within Jinja templates to a strict `{{ var.value.variable_name }}` since the Operator and Sensor both require `connector_id` args.  The `var.value.get()` call didn't have a fallback -- and unfortunately the `get()` call doesn't have one built in -- so the Variable retrieval fails anyway if one is not present in Airflow.

- Based on the docstring details, updated `FivetranOperator` and `FivetranSensor` signatures to require a `connector_id` arg passed.