### PR TITLE
Removing `@apply_defaults` decorator use

### DIFF
--- a/fivetran_provider/operators/fivetran.py
+++ b/fivetran_provider/operators/fivetran.py
@@ -51,7 +51,6 @@ class FivetranOperator(BaseOperator):
     # Define which fields get jinjaified
     template_fields = ["connector_id"]
 
-    @apply_defaults
     def __init__(
         self,
         run_name: Optional[str] = None,

--- a/fivetran_provider/operators/fivetran.py
+++ b/fivetran_provider/operators/fivetran.py
@@ -5,7 +5,6 @@ import time
 import requests
 
 from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.utils.decorators import apply_defaults
 from typing import Any, Dict, List, Optional, Union
 
 from fivetran_provider.hooks.fivetran import FivetranHook

--- a/fivetran_provider/sensors/fivetran.py
+++ b/fivetran_provider/sensors/fivetran.py
@@ -41,7 +41,6 @@ class FivetranSensor(BaseSensorOperator):
     # Define which fields get jinjaified
     template_fields = ["connector_id"]
 
-    @apply_defaults
     def __init__(
         self,
         fivetran_conn_id: str = 'fivetran',

--- a/fivetran_provider/sensors/fivetran.py
+++ b/fivetran_provider/sensors/fivetran.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from airflow.exceptions import AirflowException
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
-from airflow.utils.decorators import apply_defaults
 
 from fivetran_provider.hooks.fivetran import FivetranHook
 


### PR DESCRIPTION
As of Airflow 2.1, the `@apply_decorator` has been deprecated and is built in to the meta class of `BaseOperator`.  This has been noted a breaking change with Airflow providers.  Updating both the `FivetranOperator` and `FivetranSensor` to reflect this Airflow update.

> **Breaking changes**
Auto-apply apply_default decorator ([#15667](https://github.com/apache/airflow/pull/15667))
>
> **Warning**
Due to apply_default decorator removal, this version of the provider requires Airflow 2.1.0+. If your Airflow version is < 2.1.0, and you want to install this provider version, first upgrade Airflow to at least version 2.1.0. Otherwise your Airflow package version will be upgraded automatically and you will have to manually run airflow upgrade db to complete the migration.

To note, this update will require that this version of the provider is only compatible with Airflow 2.1+.