### PR TITLE
Parse timestamps in start_fivetran_sync

### DIFF
--- a/fivetran_provider/hooks/fivetran.py
+++ b/fivetran_provider/hooks/fivetran.py
@@ -233,8 +233,8 @@ class FivetranHook(BaseHook):
         endpoint = self.api_path_connectors + connector_id + "/force"
         self._do_api_call(("POST", endpoint))
         connector_details = self.get_connector(connector_id)
-        succeeded_at = connector_details["succeeded_at"]
-        failed_at = connector_details["failed_at"]
+        succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
+        failed_at = self._parse_timestamp(connector_details["failed_at"])
         last_sync = succeeded_at if succeeded_at > failed_at else failed_at
 
         return last_sync


### PR DESCRIPTION
Updated start_fivetran_sync to parse timestamps before setting last_sync. Previously this could return a type error as it may compare a string to None.