### PR TITLE
Add get schema API call to hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Apache Airflow Provider for Fivetran
 
 ## Upcoming 
-* (please add here)
+* Added API call to hook to return connector schemas
 
 ## [1.1.3](https://github.com/fivetran/airflow-provider-fivetran/releases/tag/v1.1.3) - 2022-12-12
 Added ability to test a Fivetran Connection type

--- a/fivetran_provider/hooks/fivetran.py
+++ b/fivetran_provider/hooks/fivetran.py
@@ -164,6 +164,21 @@ class FivetranHook(BaseHook):
         resp = self._do_api_call(("GET", endpoint))
         return resp["data"]
 
+    def get_connector_schemas(self, connector_id):
+        """
+        Fetches schema information of the connector.
+        :param connector_id: Fivetran connector_id, found in connector settings
+            page in the Fivetran user interface.
+        :type connector_id: str
+        :return: connector details
+        :rtype: Dict
+        """
+        if connector_id == "":
+            raise ValueError("No value specified for connector_id")
+        endpoint = self.api_path_connectors + connector_id + "/schemas"
+        resp = self._do_api_call(("GET", endpoint))
+        return resp["data"]
+
     def check_connector(self, connector_id):
         """
         Ensures connector configuration has been completed successfully and is in

--- a/fivetran_provider/operators/fivetran.py
+++ b/fivetran_provider/operators/fivetran.py
@@ -2,6 +2,8 @@ from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.utils.decorators import apply_defaults
 
 from fivetran_provider.hooks.fivetran import FivetranHook
+from openlineage.airflow.extractors.base import BaseExtractor, OperatorLineage
+from openlineage.common.dataset import Dataset, Field, Source
 from typing import Optional
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     requests
-    apache-airflow >= 1.10
+    apache-airflow >= 2.1.0
 
 [options.entry_points]
 # the function get_provider_info is defined in myproviderpackage.somemodule 

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -33,7 +33,7 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD = {
         "connected_by": "mournful_shalt",
         "created_at": "2021-03-05T22:58:56.238875Z",
         "succeeded_at": "2021-03-23T20:55:12.670390Z",
-        "failed_at": 'null',
+        "failed_at": "null",
         "sync_frequency": 360,
         "schedule_type": "manual",
         "status": {
@@ -42,7 +42,7 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD = {
             "update_state": "on_schedule",
             "is_historical_sync": False,
             "tasks": [],
-            "warnings": []
+            "warnings": [],
         },
         "config": {
             "latest_version": "1",
@@ -50,17 +50,51 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD = {
             "named_range": "fivetran_test_range",
             "authorization_method": "User OAuth",
             "service_version": "1",
-            "last_synced_changes__utc_": "2021-03-23 20:54"
-        }
-    }
+            "last_synced_changes__utc_": "2021-03-23 20:54",
+        },
+    },
+}
+
+MOCK_FIVETRAN_SCHEMA_RESPONSE_PAYLOAD = {
+    "code": "Success",
+    "data": {
+        "enable_new_by_default": True,
+        "schema_change_handling": "ALLOW_ALL",
+        "schemas": {
+            "google_sheets.fivetran_google_sheets_spotify": {
+                "name_in_destination": "google_sheets.fivetran_google_sheets_spotify",
+                "enabled": True,
+                "tables": {
+                    "table_1": {
+                        "name_in_destination": "table_1",
+                        "enabled": True,
+                        "sync_mode": "SOFT_DELETE",
+                        "enabled_patch_settings": {"allowed": True},
+                        "columns": {
+                            "column_1_": {
+                                "name_in_destination": "column_1",
+                                "enabled": True,
+                                "hashed": False,
+                                "enabled_patch_settings": {
+                                    "allowed": False,
+                                    "reason_code": "SYSTEM_COLUMN",
+                                    "reason": "The column does not support exclusion as it is a Primary Key",
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    },
 }
 
 
 # Mock the `conn_fivetran` Airflow connection (note the `@` after `API_SECRET`)
-@mock.patch.dict('os.environ', AIRFLOW_CONN_CONN_FIVETRAN='http://API_KEY:API_SECRET@')
+@mock.patch.dict("os.environ", AIRFLOW_CONN_CONN_FIVETRAN="http://API_KEY:API_SECRET@")
 class TestFivetranOperator(unittest.TestCase):
-    """ 
-    Test functions for Fivetran Operator. 
+    """
+    Test functions for Fivetran Operator.
 
     Mocks responses from Fivetran API.
     """
@@ -68,24 +102,30 @@ class TestFivetranOperator(unittest.TestCase):
     @requests_mock.mock()
     def test_fivetran_operator(self, m):
 
-        m.get('https://api.fivetran.com/v1/connectors/interchangeable_revenge',
-              json=MOCK_FIVETRAN_RESPONSE_PAYLOAD)
-        m.patch('https://api.fivetran.com/v1/connectors/interchangeable_revenge',
-                json=MOCK_FIVETRAN_RESPONSE_PAYLOAD)
-        m.post('https://api.fivetran.com/v1/connectors/interchangeable_revenge/force',
-               json=MOCK_FIVETRAN_RESPONSE_PAYLOAD)
+        m.get(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge",
+            json=MOCK_FIVETRAN_RESPONSE_PAYLOAD,
+        )
+        m.patch(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge",
+            json=MOCK_FIVETRAN_RESPONSE_PAYLOAD,
+        )
+        m.post(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge/force",
+            json=MOCK_FIVETRAN_RESPONSE_PAYLOAD,
+        )
 
         operator = FivetranOperator(
-            task_id='fivetran-task',
-            fivetran_conn_id='conn_fivetran',
-            connector_id='interchangeable_revenge',
+            task_id="fivetran-task",
+            fivetran_conn_id="conn_fivetran",
+            connector_id="interchangeable_revenge",
         )
 
         result = operator.execute({})
         log.info(result)
 
-        assert result['code'] == 'Success'
+        assert result["code"] == "Success"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/sensors/test_sensors.py
+++ b/tests/sensors/test_sensors.py
@@ -36,7 +36,7 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD = {
         "connected_by": "mournful_shalt",
         "created_at": "2021-03-05T22:58:56.238875Z",
         "succeeded_at": "2021-03-23T20:55:12.670390Z",
-        "failed_at": 'null',
+        "failed_at": "null",
         "sync_frequency": 360,
         "schedule_type": "manual",
         "status": {
@@ -45,7 +45,7 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD = {
             "update_state": "on_schedule",
             "is_historical_sync": False,
             "tasks": [],
-            "warnings": []
+            "warnings": [],
         },
         "config": {
             "latest_version": "1",
@@ -53,34 +53,34 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD = {
             "named_range": "fivetran_test_range",
             "authorization_method": "User OAuth",
             "service_version": "1",
-            "last_synced_changes__utc_": "2021-03-23 20:54"
-        }
-    }
+            "last_synced_changes__utc_": "2021-03-23 20:54",
+        },
+    },
 }
 
 
 # Mock the `conn_fivetran` Airflow connection (note the `@` after `API_SECRET`)
-@mock.patch.dict('os.environ', AIRFLOW_CONN_CONN_FIVETRAN='http://API_KEY:API_SECRET@')
+@mock.patch.dict("os.environ", AIRFLOW_CONN_CONN_FIVETRAN="http://API_KEY:API_SECRET@")
 class TestFivetranSensor(unittest.TestCase):
-    """ 
-    Test functions for Fivetran Operator. 
+    """
+    Test functions for Fivetran Operator.
 
     Mocks responses from Fivetran API.
     """
 
-    @mock.patch.object(FivetranSensor, 'poke', 'returned_sync_status')
+    @mock.patch.object(FivetranSensor, "poke", "returned_sync_status")
     @requests_mock.mock()
     def test_del(self, m):
 
         sensor = FivetranSensor(
-            task_id='my_fivetran_sensor',
-            fivetran_conn_id='conn_fivetran',
-            connector_id='interchangeable_revenge'
+            task_id="my_fivetran_sensor",
+            fivetran_conn_id="conn_fivetran",
+            connector_id="interchangeable_revenge",
         )
 
         log.info(sensor.poke)
-        assert sensor.poke == 'returned_sync_status'
+        assert sensor.poke == "returned_sync_status"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a get schema API call to the hook. This is a necessary addition for a corresponding PR in the async operator that adds lineage functionality.