### PR TITLE
Add the content type for post calls

### DIFF
--- a/fivetran_provider/hooks/fivetran.py
+++ b/fivetran_provider/hooks/fivetran.py
@@ -112,6 +112,7 @@ class FivetranHook(BaseHook):
             request_func = requests.get
         elif method == "POST":
             request_func = requests.post
+            headers.update({"Content-Type": "application/json;version=2"})
         elif method == "PATCH":
             request_func = requests.patch
             headers.update({"Content-Type": "application/json;version=2"})


### PR DESCRIPTION
Currently, the `POST` request does not work properly in `_do_api_call` as the Content-Type HTTP header should be set for PUT and POST requests.

Here by default the content type is not set for `POST` which results in the 415 error like the following:
```
requests.exceptions.HTTPError: 415 Client Error: Unsupported Media Type for url: https://api.fivetran.com/v1/groups/
```

This is done as part of `PATCH` calls as https://github.com/fivetran/airflow-provider-fivetran/blob/main/fivetran_provider/hooks/fivetran.py#L117
A similar change is required for `POST` calls

References:
According to the [RFC 7231 section 3.1.5.5](https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5):

> A sender that generates a message containing a payload body SHOULD generate a Content-Type header field in that message unless the intended media type of the enclosed representation is unknown to the sender. If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([[RFC2046], Section 4.5.1](https://www.rfc-editor.org/rfc/rfc2046#section-4.5.1)) or examine the data to determine its type.

It means that the Content-Type HTTP header should be set for PUT and POST requests.

- Add the following line after: https://github.com/fivetran/airflow-provider-fivetran/blob/main/fivetran_provider/hooks/fivetran.py#L114

```
 headers.update({"Content-Type": "application/json;version=2"})
```

closes: #73 